### PR TITLE
aae_progress_report and other functions needed for Tictac AAE CLI treestatus subcommand

### DIFF
--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -17,41 +17,47 @@
 -include("include/aae.hrl").
 
 -export([init/1,
-            handle_call/3,
-            handle_cast/2,
-            handle_info/2,
-            terminate/2,
-            code_change/3]).
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
 
 -export([aae_start/6,
-            aae_start/7,
-            aae_start/8,
-            aae_nextrebuild/1,
-            aae_schedulenextrebuild/2,
-            aae_put/7,
-            aae_close/1,
-            aae_destroy/1,
-            aae_fetchroot/3,
-            aae_mergeroot/3,
-            aae_fetchbranches/4,
-            aae_mergebranches/4,
-            aae_fetchclocks/5,
-            aae_fetchclocks/7,
-            aae_rebuildtrees/5,
-            aae_rebuildtrees/4,
-            aae_rebuildstore/2,
-            aae_rebuildstore/3,
-            aae_fold/6,
-            aae_fold/8,
-            aae_bucketlist/1,
-            aae_loglevel/2,
-            aae_ping/3,
-            aae_runnerprompt/1
+         aae_start/7,
+         aae_start/8,
+         aae_nextrebuild/1,
+         aae_set_rebuild_schedule/2,
+         aae_get_rebuild_schedule/1,
+         aae_schedulenextrebuild/2,
+         aae_get_storeheads/1,
+         aae_set_storeheads/2,
+         aae_get_key_store/1,
+         aae_get_tree_caches/1,
+         aae_put/7,
+         aae_close/1,
+         aae_destroy/1,
+         aae_fetchroot/3,
+         aae_mergeroot/3,
+         aae_fetchbranches/4,
+         aae_mergebranches/4,
+         aae_fetchclocks/5,
+         aae_fetchclocks/7,
+         aae_rebuildtrees/5,
+         aae_rebuildtrees/4,
+         aae_rebuildstore/2,
+         aae_rebuildstore/3,
+         aae_fold/6,
+         aae_fold/8,
+         aae_bucketlist/1,
+         aae_loglevel/2,
+         aae_ping/3,
+         aae_runnerprompt/1
         ]).
 
 -export([foldobjects_buildtrees/2,
-            hash_clocks/2,
-            wrapped_splitobjfun/1]).
+         hash_clocks/2,
+         wrapped_splitobjfun/1]).
 
 -export([wait_on_sync/5]).
 
@@ -222,6 +228,42 @@ aae_nextrebuild(Pid) ->
 %% occurred now + specified delay
 aae_schedulenextrebuild(Pid, Delay) ->
     gen_server:call(Pid, {schedule_rebuild, Delay}, ?SYNC_TIMEOUT).
+
+-spec aae_set_rebuild_schedule(pid(), rebuild_schedule()) -> ok.
+%% @doc
+%% Set rebuild schedule
+aae_set_rebuild_schedule(Pid, RS) ->
+    gen_server:call(Pid, {set_rebuild_schedule, RS}, ?SYNC_TIMEOUT).
+
+-spec aae_get_storeheads(pid()) -> ok.
+%% @doc
+%% Get storeheads
+aae_get_storeheads(Pid) ->
+    gen_server:call(Pid, get_storeheads, ?SYNC_TIMEOUT).
+
+-spec aae_set_storeheads(pid(), boolean()) -> ok.
+%% @doc
+%% Set storeheads
+aae_set_storeheads(Pid, A) ->
+    gen_server:call(Pid, {set_storeheads, A}, ?SYNC_TIMEOUT).
+
+-spec aae_get_rebuild_schedule(pid()) -> rebuild_schedule().
+%% @doc
+%% Get rebuild schedule
+aae_get_rebuild_schedule(Pid) ->
+    gen_server:call(Pid, get_rebuild_schedule, ?SYNC_TIMEOUT).
+
+-spec aae_get_key_store(pid()) -> pid() | undefined.
+%% @doc
+%% Expose key_store pid, to gather info for aae-progress-report.
+aae_get_key_store(Pid) ->
+    gen_server:call(Pid, get_key_store, ?SYNC_TIMEOUT).
+
+-spec aae_get_tree_caches(pid()) -> tree_caches().
+%% @doc
+%% Expose tree_caches, for aae-progress-report.
+aae_get_tree_caches(Pid) ->
+    gen_server:call(Pid, get_tree_caches, ?SYNC_TIMEOUT).
 
 -spec aae_put(
     pid(),
@@ -593,6 +635,22 @@ init([Opts]) ->
 
 handle_call(rebuild_time, _From, State) ->  
     {reply, State#state.next_rebuild, State};
+handle_call({set_rebuild_schedule, RS}, _From, State) ->
+    {reply, ok, State#state{rebuild_schedule = RS}};
+handle_call(get_storeheads, _From, State = #state{object_splitfun = WrapObjSplitFun}) ->
+    StoreheadsIsOn = wrapped_splitobjfun(
+                       riak_object:aae_from_object_binary(true)),
+    {reply, (StoreheadsIsOn == WrapObjSplitFun), State};
+handle_call({set_storeheads, A}, _From, State) ->
+    ObjSplitFun = riak_object:aae_from_object_binary(A),
+    WrapObjSplitFun = wrapped_splitobjfun(ObjSplitFun),
+    {reply, ok, State#state{object_splitfun = WrapObjSplitFun}};
+handle_call(get_rebuild_schedule, _From, State = #state{rebuild_schedule = RS}) ->
+    {reply, RS, State};
+handle_call(get_key_store, _From, State = #state{key_store = A}) ->
+    {reply, A, State};
+handle_call(get_tree_caches, _From, State = #state{tree_caches = A}) ->
+    {reply, A, State};
 handle_call({schedule_rebuild, Delay}, _From, State) ->
     {Mega, Sec, Micros} = os:timestamp(),
     Next = schedule_rebuild({Mega, Sec + Delay, Micros},

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -30,8 +30,8 @@
          aae_set_rebuild_schedule/2,
          aae_get_rebuild_schedule/1,
          aae_schedulenextrebuild/2,
-         aae_get_storeheads/1,
-         aae_set_storeheads/2,
+         aae_get_object_splitfun/1,
+         aae_set_object_splitfun/2,
          aae_get_key_store/1,
          aae_get_tree_caches/1,
          aae_put/7,
@@ -229,29 +229,30 @@ aae_nextrebuild(Pid) ->
 aae_schedulenextrebuild(Pid, Delay) ->
     gen_server:call(Pid, {schedule_rebuild, Delay}, ?SYNC_TIMEOUT).
 
+-spec aae_get_rebuild_schedule(pid()) -> rebuild_schedule().
+%% @doc
+%% Get rebuild schedule
+aae_get_rebuild_schedule(Pid) ->
+    gen_server:call(Pid, get_rebuild_schedule, ?SYNC_TIMEOUT).
+
 -spec aae_set_rebuild_schedule(pid(), rebuild_schedule()) -> ok.
 %% @doc
 %% Set rebuild schedule
 aae_set_rebuild_schedule(Pid, RS) ->
     gen_server:call(Pid, {set_rebuild_schedule, RS}, ?SYNC_TIMEOUT).
 
--spec aae_get_storeheads(pid()) -> ok.
+-spec aae_get_object_splitfun(pid()) -> function().
 %% @doc
-%% Get storeheads
-aae_get_storeheads(Pid) ->
-    gen_server:call(Pid, get_storeheads, ?SYNC_TIMEOUT).
+%% Get object_splitfun field. It is only used to infer the value of 'storeheads'.
+aae_get_object_splitfun(Pid) ->
+    gen_server:call(Pid, get_object_splitfun, ?SYNC_TIMEOUT).
 
--spec aae_set_storeheads(pid(), boolean()) -> ok.
+-spec aae_set_object_splitfun(pid(), function()) -> ok.
 %% @doc
-%% Set storeheads
-aae_set_storeheads(Pid, A) ->
-    gen_server:call(Pid, {set_storeheads, A}, ?SYNC_TIMEOUT).
-
--spec aae_get_rebuild_schedule(pid()) -> rebuild_schedule().
-%% @doc
-%% Get rebuild schedule
-aae_get_rebuild_schedule(Pid) ->
-    gen_server:call(Pid, get_rebuild_schedule, ?SYNC_TIMEOUT).
+%% Set object_splitfun. Used to emulate re-initing the controller
+%% with a different value of 'storeheads'.
+aae_set_object_splitfun(Pid, A) ->
+    gen_server:call(Pid, {set_object_splitfun, A}, ?SYNC_TIMEOUT).
 
 -spec aae_get_key_store(pid()) -> pid() | undefined.
 %% @doc
@@ -635,18 +636,14 @@ init([Opts]) ->
 
 handle_call(rebuild_time, _From, State) ->  
     {reply, State#state.next_rebuild, State};
-handle_call({set_rebuild_schedule, RS}, _From, State) ->
-    {reply, ok, State#state{rebuild_schedule = RS}};
-handle_call(get_storeheads, _From, State = #state{object_splitfun = WrapObjSplitFun}) ->
-    StoreheadsIsOn = wrapped_splitobjfun(
-                       riak_object:aae_from_object_binary(true)),
-    {reply, (StoreheadsIsOn == WrapObjSplitFun), State};
-handle_call({set_storeheads, A}, _From, State) ->
-    ObjSplitFun = riak_object:aae_from_object_binary(A),
-    WrapObjSplitFun = wrapped_splitobjfun(ObjSplitFun),
-    {reply, ok, State#state{object_splitfun = WrapObjSplitFun}};
 handle_call(get_rebuild_schedule, _From, State = #state{rebuild_schedule = RS}) ->
     {reply, RS, State};
+handle_call({set_rebuild_schedule, RS}, _From, State) ->
+    {reply, ok, State#state{rebuild_schedule = RS}};
+handle_call(get_object_splitfun, _From, State = #state{object_splitfun = A}) ->
+    {reply, A, State};
+handle_call({set_object_splitfun, A}, _From, State) ->
+    {reply, ok, State#state{object_splitfun = A}};
 handle_call(get_key_store, _From, State = #state{key_store = A}) ->
     {reply, A, State};
 handle_call(get_tree_caches, _From, State = #state{tree_caches = A}) ->

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -27,6 +27,7 @@
             aae_start/7,
             aae_start/8,
             aae_nextrebuild/1,
+            aae_schedulenextrebuild/2,
             aae_put/7,
             aae_close/1,
             aae_destroy/1,
@@ -214,6 +215,13 @@ aae_start(
 %% When is the next keystore rebuild process scheduled for
 aae_nextrebuild(Pid) ->
     gen_server:call(Pid, rebuild_time, ?SYNC_TIMEOUT).
+
+-spec aae_schedulenextrebuild(pid(), non_neg_integer()) -> ok.
+%% @doc
+%% Schedule the next keystore rebuild, assuming last rebuild
+%% occurred now + specified delay
+aae_schedulenextrebuild(Pid, Delay) ->
+    gen_server:call(Pid, {schedule_rebuild, Delay}, ?SYNC_TIMEOUT).
 
 -spec aae_put(
     pid(),
@@ -585,6 +593,11 @@ init([Opts]) ->
 
 handle_call(rebuild_time, _From, State) ->  
     {reply, State#state.next_rebuild, State};
+handle_call({schedule_rebuild, Delay}, _From, State) ->
+    {Mega, Sec, Micros} = os:timestamp(),
+    Next = schedule_rebuild({Mega, Sec + Delay, Micros},
+                            State#state.rebuild_schedule),
+    {reply, ok, State#state{next_rebuild = Next}};
 handle_call(close, _From, State) ->
     ok = maybe_flush_puts(State#state.key_store, 
                             State#state.objectspecs_queue,

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -1005,8 +1005,10 @@ handle_call(bucket_list,  _From, State) ->
                             true),
     R = aae_keystore:store_bucketlist(State#state.key_store),
     {reply, R, State};
-handle_call(produce_report, _From, State) ->
-    R = produce_report(State),
+handle_call(produce_report, _From, State = #state{key_store = KeyStore,
+                                                  next_rebuild = NextRebuild,
+                                                  tree_caches = TreeCaches}) ->
+    R = produce_report(KeyStore, NextRebuild, TreeCaches),
     {reply, R, State};
 handle_call({ping, RequestTime}, _From, State) ->
     T = max(0, timer:now_diff(os:timestamp(), RequestTime)),
@@ -1217,9 +1219,7 @@ wrapped_splitobjfun(ObjectSplitFun) ->
         end
     end.
 
-produce_report(#state{key_store = KeyStore,
-                      next_rebuild = NextRebuild,
-                      tree_caches = TreeCaches}) ->
+produce_report(KeyStore, NextRebuild, TreeCaches) ->
     KeyStoreCurrentStatus =
         if is_pid(KeyStore) ->
                 element(1, aae_keystore:store_currentstatus(KeyStore));

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -223,8 +223,7 @@ aae_nextrebuild(Pid) ->
 
 -spec aae_prompt_nextrebuild(pid(), non_neg_integer()) -> ok.
 %% @doc
-%% Schedule the next keystore rebuild, assuming last rebuild
-%% occurred now + specified delay
+%% Set the next_rebuild time to now + given delay
 aae_prompt_nextrebuild(Pid, Delay) ->
     gen_server:call(Pid, {prompt_nextrebuild, Delay}, ?SYNC_TIMEOUT).
 
@@ -640,11 +639,9 @@ handle_call(get_object_splitfun, _From, State = #state{object_splitfun = A}) ->
     {reply, A, State};
 handle_call({set_object_splitfun, A}, _From, State) ->
     {reply, ok, State#state{object_splitfun = A}};
-handle_call({prompt_nextrebuild, Delay}, _From, State) ->
+handle_call({prompt_nextrebuild, SecsFromNow}, _From, State) ->
     {Mega, Sec, Micros} = os:timestamp(),
-    Next = schedule_rebuild({Mega, Sec + Delay, Micros},
-                            State#state.rebuild_schedule),
-    {reply, ok, State#state{next_rebuild = Next}};
+    {reply, ok, State#state{next_rebuild = {Mega, Sec + SecsFromNow, Micros}}};
 handle_call(close, _From, State) ->
     ok = maybe_flush_puts(State#state.key_store, 
                             State#state.objectspecs_queue,

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -1217,18 +1217,10 @@ wrapped_splitobjfun(ObjectSplitFun) ->
     end.
 
 produce_report(KeyStore, NextRebuild, TreeCaches) ->
-    KeyStoreCurrentStatus =
-        if is_pid(KeyStore) ->
-                element(1, aae_keystore:store_currentstatus(KeyStore));
-           el/=se ->
-                not_running
-        end,
-
     TotalDirtySegments =
         lists:sum(
           [aae_treecache:cache_segment_count(P) || {_, P} <- TreeCaches]),
-    [{key_store_current_status, KeyStoreCurrentStatus},
-     {last_rebuild, aae_keystore:store_last_rebuild(KeyStore)},
+    [{last_rebuild, aae_keystore:store_last_rebuild(KeyStore)},
      {next_rebuild, NextRebuild},
      {total_dirty_segments, TotalDirtySegments}
     ].

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -32,8 +32,6 @@
          aae_schedulenextrebuild/2,
          aae_get_object_splitfun/1,
          aae_set_object_splitfun/2,
-         aae_get_key_store/1,
-         aae_get_tree_caches/1,
          aae_put/7,
          aae_close/1,
          aae_destroy/1,
@@ -52,7 +50,8 @@
          aae_bucketlist/1,
          aae_loglevel/2,
          aae_ping/3,
-         aae_runnerprompt/1
+         aae_runnerprompt/1,
+         aae_report/1
         ]).
 
 -export([foldobjects_buildtrees/2,
@@ -253,18 +252,6 @@ aae_get_object_splitfun(Pid) ->
 %% with a different value of 'storeheads'.
 aae_set_object_splitfun(Pid, A) ->
     gen_server:call(Pid, {set_object_splitfun, A}, ?SYNC_TIMEOUT).
-
--spec aae_get_key_store(pid()) -> pid() | undefined.
-%% @doc
-%% Expose key_store pid, to gather info for aae-progress-report.
-aae_get_key_store(Pid) ->
-    gen_server:call(Pid, get_key_store, ?SYNC_TIMEOUT).
-
--spec aae_get_tree_caches(pid()) -> tree_caches().
-%% @doc
-%% Expose tree_caches, for aae-progress-report.
-aae_get_tree_caches(Pid) ->
-    gen_server:call(Pid, get_tree_caches, ?SYNC_TIMEOUT).
 
 -spec aae_put(
     pid(),
@@ -532,6 +519,10 @@ aae_ping(Pid, RequestTime, From) ->
 aae_runnerprompt(Pid) ->
     gen_server:cast(Pid, runner_prompt).
 
+-spec aae_report(pid()) -> list({atom(), term()}).
+aae_report(Pid) ->
+    gen_server:call(Pid, produce_report).
+
 
 %%%============================================================================
 %%% gen_server callbacks
@@ -644,10 +635,6 @@ handle_call(get_object_splitfun, _From, State = #state{object_splitfun = A}) ->
     {reply, A, State};
 handle_call({set_object_splitfun, A}, _From, State) ->
     {reply, ok, State#state{object_splitfun = A}};
-handle_call(get_key_store, _From, State = #state{key_store = A}) ->
-    {reply, A, State};
-handle_call(get_tree_caches, _From, State = #state{tree_caches = A}) ->
-    {reply, A, State};
 handle_call({schedule_rebuild, Delay}, _From, State) ->
     {Mega, Sec, Micros} = os:timestamp(),
     Next = schedule_rebuild({Mega, Sec + Delay, Micros},
@@ -1013,6 +1000,9 @@ handle_call(bucket_list,  _From, State) ->
                             true),
     R = aae_keystore:store_bucketlist(State#state.key_store),
     {reply, R, State};
+handle_call(produce_report, _From, State) ->
+    R = produce_report(State),
+    {reply, R, State};
 handle_call({ping, RequestTime}, _From, State) ->
     T = max(0, timer:now_diff(os:timestamp(), RequestTime)),
     aae_util:log(aae15, [T div 1000], State#state.log_levels),
@@ -1221,6 +1211,26 @@ wrapped_splitobjfun(ObjectSplitFun) ->
                 T
         end
     end.
+
+produce_report(#state{key_store = KeyStore,
+                      next_rebuild = NextRebuild,
+                      tree_caches = TreeCaches}) ->
+    KeyStoreCurrentStatus =
+        if is_pid(KeyStore) ->
+                element(1, aae_keystore:store_currentstatus(KeyStore));
+           el/=se ->
+                not_running
+        end,
+
+    TotalDirtySegments =
+        lists:sum(
+          [aae_treecache:cache_segment_count(P) || {_, P} <- TreeCaches]),
+    [{key_store_current_status, KeyStoreCurrentStatus},
+     {last_rebuild, aae_keystore:store_last_rebuild(KeyStore)},
+     {next_rebuild, NextRebuild},
+     {total_dirty_segments, TotalDirtySegments}
+    ].
+
 
 %%%============================================================================
 %%% Internal functions

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -51,7 +51,7 @@
          aae_loglevel/2,
          aae_ping/3,
          aae_runnerprompt/1,
-         aae_report/1
+         aae_produce_progress_report/1
         ]).
 
 -export([foldobjects_buildtrees/2,
@@ -519,8 +519,13 @@ aae_ping(Pid, RequestTime, From) ->
 aae_runnerprompt(Pid) ->
     gen_server:cast(Pid, runner_prompt).
 
--spec aae_report(pid()) -> list({atom(), term()}).
-aae_report(Pid) ->
+-spec aae_produce_progress_report(pid()) -> list({atom(), term()}).
+%% @doc
+%% Generate a 'progress report', with items such as status,
+%% last_rebuild, next_rebuild, for the aae controller handling this
+%% partition. This report can be displayed by `riak admin tictacaae
+%% treestatus` command.
+aae_produce_progress_report(Pid) ->
     gen_server:call(Pid, produce_report).
 
 

--- a/src/aae_controller.erl
+++ b/src/aae_controller.erl
@@ -29,7 +29,7 @@
          aae_nextrebuild/1,
          aae_set_rebuild_schedule/2,
          aae_get_rebuild_schedule/1,
-         aae_schedulenextrebuild/2,
+         aae_prompt_nextrebuild/2,
          aae_get_object_splitfun/1,
          aae_set_object_splitfun/2,
          aae_put/7,
@@ -221,12 +221,12 @@ aae_start(
 aae_nextrebuild(Pid) ->
     gen_server:call(Pid, rebuild_time, ?SYNC_TIMEOUT).
 
--spec aae_schedulenextrebuild(pid(), non_neg_integer()) -> ok.
+-spec aae_prompt_nextrebuild(pid(), non_neg_integer()) -> ok.
 %% @doc
 %% Schedule the next keystore rebuild, assuming last rebuild
 %% occurred now + specified delay
-aae_schedulenextrebuild(Pid, Delay) ->
-    gen_server:call(Pid, {schedule_rebuild, Delay}, ?SYNC_TIMEOUT).
+aae_prompt_nextrebuild(Pid, Delay) ->
+    gen_server:call(Pid, {prompt_nextrebuild, Delay}, ?SYNC_TIMEOUT).
 
 -spec aae_get_rebuild_schedule(pid()) -> rebuild_schedule().
 %% @doc
@@ -640,7 +640,7 @@ handle_call(get_object_splitfun, _From, State = #state{object_splitfun = A}) ->
     {reply, A, State};
 handle_call({set_object_splitfun, A}, _From, State) ->
     {reply, ok, State#state{object_splitfun = A}};
-handle_call({schedule_rebuild, Delay}, _From, State) ->
+handle_call({prompt_nextrebuild, Delay}, _From, State) ->
     {Mega, Sec, Micros} = os:timestamp(),
     Next = schedule_rebuild({Mega, Sec + Delay, Micros},
                             State#state.rebuild_schedule),

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -2,16 +2,18 @@
 -include_lib("common_test/include/ct.hrl").
 -export([all/0, init_per_suite/1, end_per_suite/1]).
 -export([dual_store_compare_medium_so/1,
-            dual_store_compare_medium_ko/1,
-            dual_store_compare_large_so/1,
-            dual_store_compare_large_ko/1,
-            store_notsupported/1]).
+         dual_store_compare_medium_ko/1,
+         dual_store_compare_large_so/1,
+         dual_store_compare_large_ko/1,
+         store_notsupported/1,
+         get_set_rebuild_schedule/1]).
 
 all() -> [dual_store_compare_medium_so,
-            dual_store_compare_medium_ko,
-            dual_store_compare_large_so,
-            dual_store_compare_large_ko,
-            store_notsupported
+          dual_store_compare_medium_ko,
+          dual_store_compare_large_so,
+          dual_store_compare_large_ko,
+          store_notsupported,
+          get_set_rebuild_schedule
         ].
 
 init_per_suite(Config) ->
@@ -20,6 +22,44 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     testutil:end_per_suite(Config).
+
+get_set_rebuild_schedule(_Config) ->
+    RootPath = testutil:reset_filestructure(),
+    VnodePath1 = filename:join(RootPath, "vnode1/"),
+    SplitF = fun(_X) -> {_SomeSensibleSize = 42, 1, 0, undefined, <<>>} end,
+    RS0 = {1, 300},
+
+    {ok, Cntrl} =
+        aae_controller:aae_start({parallel, leveled_ko},
+                                 true,
+                                 RS0,
+                                 [{2, 0}, {2, 1}],
+                                 VnodePath1,
+                                 SplitF),
+
+    BKVList = testutil:gen_keys([], 100),
+    ok = testutil:put_keys(Cntrl, 2, BKVList, none),
+
+    ok = test_rebuild_schedule(Cntrl, RS0),
+
+    aae_controller:aae_close(Cntrl),
+    RootPath = testutil:reset_filestructure().
+
+test_rebuild_schedule(Cntrl, RS0) ->
+    RS1 = {RS1a, RS1b} = aae_controller:aae_get_rebuild_schedule(Cntrl),
+    RS1 = RS0,
+    ok = aae_controller:aae_set_rebuild_schedule(Cntrl, {RS1a, RS1b + 1}),
+    {RS2a, RS2b} = aae_controller:aae_get_rebuild_schedule(Cntrl),
+    RS1a = RS2a,
+    RS2b = RS1b + 1,
+    ok = aae_controller:aae_set_rebuild_schedule(Cntrl, {RS1a + 1, RS1b}),
+    {RS3a, RS3b} = aae_controller:aae_get_rebuild_schedule(Cntrl),
+    RS3a = RS1a + 1,
+    RS1b = RS3b,
+    ok.
+
+
+
         
 store_notsupported(_Config) ->
     RootPath = testutil:reset_filestructure(),

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -9,12 +9,12 @@
          get_set_rebuild_schedule/1,
          get_set_storeheads/1]).
 
-all() -> [%dual_store_compare_medium_so,
-          %dual_store_compare_medium_ko,
-          %dual_store_compare_large_so,
-          %dual_store_compare_large_ko,
-          %store_notsupported,
-          %get_set_rebuild_schedule,
+all() -> [dual_store_compare_medium_so,
+          dual_store_compare_medium_ko,
+          dual_store_compare_large_so,
+          dual_store_compare_large_ko,
+          store_notsupported,
+          get_set_rebuild_schedule,
           get_set_storeheads
          ].
 

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -124,27 +124,6 @@ get_set_storeheads(_Config) ->
     true = (SCF0 /= SCF2),
     ?NEW_SIBLING_COUNT = element(2, SCF2),
 
-    %% force rebuild
-    {ok, _, _} = aae_controller:aae_rebuildtrees(
-                   Cntrl, Preflist, fun testutil:calc_preflist/2, false),
-    %% re-test query
-    ct:print("trees force-rebuilt\n"),
-
-    SCFolder3 = key_range_folder(Cntrl, Bucket, StartKey, EndKey),
-    SCF3 = SCFolder3(),
-    ct:print("after rebuilding, query returns ~b siblings\n", [element(2, SCF3)]),
-    ?NEW_SIBLING_COUNT = element(2, SCF3),
-
-    %% update split_function
-    ok = aae_controller:aae_set_object_splitfun(Cntrl, StoreheadsOnSplitF),
-    ct:print("set storeheads back to on, expect sibling count to remain ~b\n",
-             [?NEW_SIBLING_COUNT]),
-
-    SCFolder4 = key_range_folder(Cntrl, Bucket, StartKey, EndKey),
-    SCF4 = SCFolder4(),
-    ?NEW_SIBLING_COUNT = element(2, SCF4),
-    ct:print("~b indeed\n", [element(2, SCF4)]),
-
     aae_controller:aae_close(Cntrl),
     RootPath = testutil:reset_filestructure().
 

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -7,7 +7,9 @@
          dual_store_compare_large_ko/1,
          store_notsupported/1,
          get_set_rebuild_schedule/1,
-         get_set_storeheads/1]).
+         get_set_storeheads/1,
+         get_set_nextrebuild/1
+        ]).
 
 all() -> [dual_store_compare_medium_so,
           dual_store_compare_medium_ko,
@@ -15,7 +17,8 @@ all() -> [dual_store_compare_medium_so,
           dual_store_compare_large_ko,
           store_notsupported,
           get_set_rebuild_schedule,
-          get_set_storeheads
+          get_set_storeheads,
+          get_set_nextrebuild
          ].
 
 init_per_suite(Config) ->
@@ -56,6 +59,34 @@ test_rebuild_schedule(Cntrl, RS0) ->
     RS3a = RS1a + 1,
     RS1b = RS3b,
     ok.
+
+get_set_nextrebuild(_Config) ->
+    RootPath = testutil:reset_filestructure(),
+    VnodePath1 = filename:join(RootPath, "vnode1/"),
+    SplitF = fun(_) -> {42, 1, 0, null} end,
+
+    {ok, Cntrl} =
+        aae_controller:aae_start({parallel, leveled_ko},
+                                 true,
+                                 {1, 300},
+                                 [{2, 0}, {2, 1}],
+                                 VnodePath1,
+                                 SplitF),
+
+    NextRebuild0 = aae_controller:aae_nextrebuild(Cntrl),
+    Now = os:timestamp(),
+    ok = aae_controller:aae_prompt_nextrebuild(Cntrl, 10),
+    NextRebuild1 = aae_controller:aae_nextrebuild(Cntrl),
+    true = (NextRebuild1 /= NextRebuild0),
+    Report = aae_controller:aae_produce_progress_report(Cntrl),
+    NextRebuild1Reported = proplists:get_value(next_rebuild, Report),
+    NextRebuild1Reported = NextRebuild1,
+    ApproxTenSec = timer:now_diff(NextRebuild1, Now) div 1000000,
+    true = (ApproxTenSec > 9),
+    true = (ApproxTenSec < 11),
+
+    aae_controller:aae_close(Cntrl),
+    testutil:reset_filestructure().
 
 -define(NKEYS, 15).
 -define(NKEYS_IN_RANGE, 9).

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -6,15 +6,17 @@
          dual_store_compare_large_so/1,
          dual_store_compare_large_ko/1,
          store_notsupported/1,
-         get_set_rebuild_schedule/1]).
+         get_set_rebuild_schedule/1,
+         get_set_storeheads/1]).
 
-all() -> [dual_store_compare_medium_so,
-          dual_store_compare_medium_ko,
-          dual_store_compare_large_so,
-          dual_store_compare_large_ko,
-          store_notsupported,
-          get_set_rebuild_schedule
-        ].
+all() -> [%dual_store_compare_medium_so,
+          %dual_store_compare_medium_ko,
+          %dual_store_compare_large_so,
+          %dual_store_compare_large_ko,
+          %store_notsupported,
+          %get_set_rebuild_schedule,
+          get_set_storeheads
+         ].
 
 init_per_suite(Config) ->
     testutil:init_per_suite([{suite, "basic"}|Config]),
@@ -26,7 +28,7 @@ end_per_suite(Config) ->
 get_set_rebuild_schedule(_Config) ->
     RootPath = testutil:reset_filestructure(),
     VnodePath1 = filename:join(RootPath, "vnode1/"),
-    SplitF = fun(_X) -> {_SomeSensibleSize = 42, 1, 0, undefined, <<>>} end,
+    SplitF = fun(_) -> {_SomeSensibleSize = 42, 1, 0, undefined, <<>>} end,
     RS0 = {1, 300},
 
     {ok, Cntrl} =
@@ -37,13 +39,10 @@ get_set_rebuild_schedule(_Config) ->
                                  VnodePath1,
                                  SplitF),
 
-    BKVList = testutil:gen_keys([], 100),
-    ok = testutil:put_keys(Cntrl, 2, BKVList, none),
-
     ok = test_rebuild_schedule(Cntrl, RS0),
 
     aae_controller:aae_close(Cntrl),
-    RootPath = testutil:reset_filestructure().
+    testutil:reset_filestructure().
 
 test_rebuild_schedule(Cntrl, RS0) ->
     RS1 = {RS1a, RS1b} = aae_controller:aae_get_rebuild_schedule(Cntrl),
@@ -58,9 +57,116 @@ test_rebuild_schedule(Cntrl, RS0) ->
     RS1b = RS3b,
     ok.
 
+-define(NKEYS, 15).
+-define(NKEYS_IN_RANGE, 9).
+-define(NKEYS_UPDATED, 5).
+-define(NEW_SIBLING_COUNT, (?NKEYS_IN_RANGE + (?NKEYS_IN_RANGE - ?NKEYS_UPDATED))).
+
+get_set_storeheads(_Config) ->
+    RootPath = testutil:reset_filestructure(),
+    VnodePath = filename:join(RootPath, "vnode1/"),
+    Preflist = [{2, 0}, {2, 1}],
+
+    StoreheadsOnSplitF = fun(_) -> {_SomeSensibleSize = 42, 1, 0, undefined, <<>>} end,
+    StoreheadsOffSplitF = fun(_) -> {42, _DoubleSiblingCount = 2, 0, undefined, <<>>} end,
+
+    {ok, Cntrl} =
+        aae_controller:aae_start({parallel, leveled_ko},
+                                 true,
+                                 {1, 300},
+                                 Preflist,
+                                 VnodePath,
+                                 StoreheadsOffSplitF,
+                                 [info, warn, error, critical]),  %% have one function
+
+    Bucket = <<"b1">>,
+    BKVList = testutil:gen_keys([], ?NKEYS, Bucket),
+    {BKVList1, _} = lists:split(?NKEYS_UPDATED, BKVList),
+    ok = testutil:put_keys(Cntrl, 2, BKVList, none),
+    ct:print("put ~b keys: ~p\n", [?NKEYS, BKVList]),
+
+    StartKey = list_to_binary(string:right(integer_to_list(0), 6, $0)),
+    EndKey = list_to_binary(string:right(integer_to_list(10), 6, $0)),
+
+    %% there be 9*2 siblings in the range
+    SCFolder0 = key_range_folder(Cntrl, Bucket, StartKey, EndKey),
+
+    %% test query
+    SCF0 = SCFolder0(),
+    ct:print("storeheads is initially off: test query should return ~b siblings:\n~b indeed\n",
+             [?NKEYS_IN_RANGE * 2, element(2, SCF0)]),
+    ?NKEYS_IN_RANGE * 2 = element(2, SCF0),
+
+    %% update split_function
+    ok = aae_controller:aae_set_object_splitfun(Cntrl, StoreheadsOnSplitF),
+    ct:print("storeheads now set to on\n"),
+
+    %% test query: no change in output
+    SCFolder1 = key_range_folder(Cntrl, Bucket, StartKey, EndKey),
+    SCF1 = SCFolder1(),
+    ct:print("after setting storeheads to on, expect no change in query output:\n"
+             "number of siblings returned is still ~b\n",
+             [element(2, SCF1)]),
+    ?NKEYS_IN_RANGE * 2 = element(2, SCF1),
+    true = (SCF0 == SCF1),
+
+    %% update some objects
+    BKVList1Updated =
+        [{B, K, [{<<V/binary, "UPDATED">>, C}]} || {B, K, [{V, C}]} <- BKVList1],
+    ok = testutil:put_keys(Cntrl, 2, BKVList1Updated, none),
+    ct:print("update ~b objects\n", [?NKEYS_UPDATED]),
+
+    %% test query to show partial change
+    SCFolder2 = key_range_folder(Cntrl, Bucket, StartKey, EndKey),
+    SCF2 = SCFolder2(),
+    ct:print("after updating, there should be a partial change (minus ~b siblings). Query returns ~b siblings:\n",
+             [?NKEYS_UPDATED, element(2, SCF2)]),
+    true = (SCF0 /= SCF2),
+    ?NEW_SIBLING_COUNT = element(2, SCF2),
+
+    %% force rebuild
+    {ok, _, _} = aae_controller:aae_rebuildtrees(
+                   Cntrl, Preflist, fun testutil:calc_preflist/2, false),
+    %% re-test query
+    ct:print("trees force-rebuilt\n"),
+
+    SCFolder3 = key_range_folder(Cntrl, Bucket, StartKey, EndKey),
+    SCF3 = SCFolder3(),
+    ct:print("after rebuilding, query returns ~b siblings\n", [element(2, SCF3)]),
+    ?NEW_SIBLING_COUNT = element(2, SCF3),
+
+    %% update split_function
+    ok = aae_controller:aae_set_object_splitfun(Cntrl, StoreheadsOnSplitF),
+    ct:print("set storeheads back to on, expect sibling count to remain ~b\n",
+             [?NEW_SIBLING_COUNT]),
+
+    SCFolder4 = key_range_folder(Cntrl, Bucket, StartKey, EndKey),
+    SCF4 = SCFolder4(),
+    ?NEW_SIBLING_COUNT = element(2, SCF4),
+    ct:print("~b indeed\n", [element(2, SCF4)]),
+
+    aae_controller:aae_close(Cntrl),
+    RootPath = testutil:reset_filestructure().
+
+key_range_folder(Cntrl, Bucket, StartKey, EndKey) ->
+    Elements = [{sibcount, null}],
+    SCFoldFun =
+        fun(_FB, FK, FV, {FAccKL, FAccSc}) ->
+            {sibcount, FSc} = lists:keyfind(sibcount, 1, FV),
+            if (FK >= StartKey) and (FK < EndKey) ->
+                    {[FK|FAccKL], FAccSc + FSc};
+               el/=se ->
+                    {FAccKL, FAccSc}
+            end
+        end,
+    SCInitAcc = {[], 0},
+    {async, Folder} =
+        aae_controller:aae_fold(
+          Cntrl, {key_range, Bucket, StartKey, EndKey},
+          all, SCFoldFun, SCInitAcc, Elements),
+    Folder.
 
 
-        
 store_notsupported(_Config) ->
     RootPath = testutil:reset_filestructure(),
     VnodePath1 = filename:join(RootPath, "vnode1/"),

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -8,7 +8,8 @@
          store_notsupported/1,
          get_set_rebuild_schedule/1,
          get_set_storeheads/1,
-         get_set_nextrebuild/1
+         get_set_nextrebuild/1,
+         splitfun_compare_functions/1
         ]).
 
 all() -> [dual_store_compare_medium_so,
@@ -18,7 +19,8 @@ all() -> [dual_store_compare_medium_so,
           store_notsupported,
           get_set_rebuild_schedule,
           get_set_storeheads,
-          get_set_nextrebuild
+          get_set_nextrebuild,
+          splitfun_compare_functions
          ].
 
 init_per_suite(Config) ->
@@ -157,6 +159,47 @@ get_set_storeheads(_Config) ->
 
     aae_controller:aae_close(Cntrl),
     RootPath = testutil:reset_filestructure().
+
+
+splitfun_compare_functions(_Config) ->
+    RootPath = testutil:reset_filestructure(),
+    VnodePath = filename:join(RootPath, "vnode1/"),
+    Preflist = [{2, 0}],
+
+    SplitF_1 = mock_aae_from_object_binary_for_storeheads(true),
+    SplitF_2 = mock_aae_from_object_binary_for_storeheads(false),
+
+    {ok, Cntrl} =
+        aae_controller:aae_start({parallel, leveled_ko},
+                                 true,
+                                 {1, 300},
+                                 Preflist,
+                                 VnodePath,
+                                 SplitF_1,
+                                 [info, warn, error, critical]),  %% have one function
+
+    %% this is essentially to test that two logically identical functions
+    %% created separately, do indeed compare equal
+    true = (aae_controller:wrapped_splitobjfun(SplitF_1) ==
+                aae_controller:aae_get_object_splitfun(Cntrl)),
+    ok = aae_controller:aae_set_object_splitfun(
+           Cntrl, aae_controller:wrapped_splitobjfun(SplitF_2)),
+    true = (aae_controller:wrapped_splitobjfun(SplitF_2) ==
+                aae_controller:aae_get_object_splitfun(Cntrl)),
+
+    aae_controller:aae_close(Cntrl),
+    RootPath = testutil:reset_filestructure().
+
+-define(APOINTINTIME, {1747,917445,410090}).
+mock_aae_from_object_binary_for_storeheads(true) ->
+    fun(_ObjBin) ->
+        {_Size = 42, _SibCount = 1, 0, _LastMods = [?APOINTINTIME], <<>>}
+    end;
+mock_aae_from_object_binary_for_storeheads(false) ->
+    fun(_) ->
+        {42, 1, 0, [?APOINTINTIME], term_to_binary(null)}
+    end.
+
 
 key_range_folder(Cntrl, Bucket, StartKey, EndKey) ->
     Elements = [{sibcount, null}],

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -105,17 +105,22 @@ clear_all(RootPath) ->
     lists:foreach(FoldFun, FNs).
 
 gen_keys(KeyList, Count) ->
-    gen_keys(KeyList, Count, 0).
+    gen_keys(KeyList, Count, spread_over_buckets).
 
-gen_keys(KeyList, Count, Floor) when Count == Floor ->
+gen_keys(KeyList, Count, BucketSpec) ->
+    gen_keys(KeyList, Count, BucketSpec, 0).
+
+gen_keys(KeyList, Count, _, Floor) when Count == Floor ->
     KeyList;
-gen_keys(KeyList, Count, Floor) ->
-    Bucket = integer_to_binary(Count rem 5),  
+gen_keys(KeyList, Count, BucketSpec, Floor) ->
+    Bucket = case BucketSpec of
+                 spread_over_buckets -> integer_to_binary(Count rem 5);
+                 _ -> BucketSpec end,
     Key = list_to_binary(string:right(integer_to_list(Count), 6, $0)),
     VersionVector = add_randomincrement([]),
     gen_keys([{Bucket, Key, VersionVector}|KeyList], 
                 Count - 1,
-                Floor).
+                BucketSpec, Floor).
 
 put_keys(Cntrl, NVal, KL) ->
     put_keys(Cntrl, NVal, KL, none).

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -1,18 +1,18 @@
 -module(testutil).
 
 -export([gen_keys/2,
-            gen_keys/3,
-            put_keys/3,
-            put_keys/4,
-            remove_keys/3,
-            gen_riakobjects/3]).
+         gen_keys/3,
+         put_keys/3,
+         put_keys/4,
+         remove_keys/3,
+         gen_riakobjects/3]).
 -export([calc_preflist/2]).
--export([start_receiver/0, 
-            exchange_sendfun/1,
-            exchange_vnodesendfun/1,
-            repair_fun/3]).
+-export([start_receiver/0,
+         exchange_sendfun/1,
+         exchange_vnodesendfun/1,
+         repair_fun/3]).
 -export([reset_filestructure/0,
-            reset_filestructure/2]).
+         reset_filestructure/2]).
 
 
 -export([init_per_suite/1, end_per_suite/1]).
@@ -107,6 +107,8 @@ clear_all(RootPath) ->
 gen_keys(KeyList, Count) ->
     gen_keys(KeyList, Count, spread_over_buckets).
 
+gen_keys(KeyList, Count, Floor) when is_integer(Floor) ->
+    gen_keys(KeyList, Count, spread_over_buckets, Floor);
 gen_keys(KeyList, Count, BucketSpec) ->
     gen_keys(KeyList, Count, BucketSpec, 0).
 
@@ -118,7 +120,7 @@ gen_keys(KeyList, Count, BucketSpec, Floor) ->
                  _ -> BucketSpec end,
     Key = list_to_binary(string:right(integer_to_list(Count), 6, $0)),
     VersionVector = add_randomincrement([]),
-    gen_keys([{Bucket, Key, VersionVector}|KeyList], 
+    gen_keys([{Bucket, Key, VersionVector}|KeyList],
                 Count - 1,
                 BucketSpec, Floor).
 


### PR DESCRIPTION
This PR adds ~getters for some controller state records~ functions needed for [TicTac AAE and NextGenRepl CLI commands](https://github.com/orgs/OpenRiak/discussions/10) (main body of work is in this [PR in riak_kv](https://github.com/OpenRiak/riak_kv/pull/55)):

* `aae_controller:aae_produce_progress_report/1`, to collect and generate a "progress report" of tree (re)building status, used by `riak admin tictacaae treestatus` command;
* `aae_controller:aae_schedulenextrebuild/2`, which can be used to trigger a tree rebuild, at a specified delay.